### PR TITLE
Fix increasing #bins at next call

### DIFF
--- a/DirectDmTargets/detector.py
+++ b/DirectDmTargets/detector.py
@@ -509,6 +509,9 @@ class DetectorSpectrum(GenSpectrum):
         events = np.array(smear_signal(rates, energies, sigma, bin_width))
         # re-bin final result to the desired number of bins
         events = self.chuck_integration(events, energies, result_bins)
+        
+        # Set the bins back to the default 
+        self.n_bins = self.n_bins_result 
         return events * self.experiment['exp_eff']
 
     def get_events(self):

--- a/DirectDmTargets/detector.py
+++ b/DirectDmTargets/detector.py
@@ -509,9 +509,9 @@ class DetectorSpectrum(GenSpectrum):
         events = np.array(smear_signal(rates, energies, sigma, bin_width))
         # re-bin final result to the desired number of bins
         events = self.chuck_integration(events, energies, result_bins)
-        
-        # Set the bins back to the default 
-        self.n_bins = self.n_bins_result 
+
+        # Set the bins back to the default
+        self.n_bins = self.n_bins_result
         return events * self.experiment['exp_eff']
 
     def get_events(self):


### PR DESCRIPTION
Every time the detector spectrum is called, we set the number of bins *10
```python
s = dddm.DetectorSpectrum(1, 10e-38, dddm.SHM(), dddm.experiment['Ge_migd_iZIP_Si_bg'])
s.get_data(poisson=False)
s.get_data(poisson=False)
```
yields 100 bins