### PR TITLE
Don't use save-intermediate or emax for run_combined_multinest

### DIFF
--- a/DirectDmTargets/statistics.py
+++ b/DirectDmTargets/statistics.py
@@ -418,6 +418,7 @@ class StatModel:
         binned_spectrum = spectrum.get_data(
             poisson=self.config['poisson'] if poisson is None else poisson
         )
+        self.log.warning(f'Check spectrum, {spectrum.E_max} keV E_max')
 
         if self.config['save_intermediate']:
             self.save_intermediate_result(binned_spectrum, interm_file)
@@ -426,7 +427,10 @@ class StatModel:
     def eval_benchmark(self):
         self.log.info(
             f'StatModel::\tpreparing for running, setting the benchmark')
-        self.benchmark_values = self.check_spectrum(poisson=False)['counts']
+        df = self.check_spectrum(poisson=False)
+        print(df)
+        time.sleep(10)
+        self.benchmark_values = df['counts']
         self.bench_is_set = True
         # Save a copy of the benchmark in the config file
         self.config['benchmark_values'] = list(self.benchmark_values)

--- a/notebooks/load_results_multinest.py
+++ b/notebooks/load_results_multinest.py
@@ -310,6 +310,7 @@ def one_confidence_plot(
 
 
 def _confidence_plot(item, X, Y, H, bin_range, text_box=False, nsigma=3,
+                     make_xticks = True,
                      cbar_note="", cmap=cm.inferno_r, alpha=1,
                      ):
     xmean, xerr = weighted_avg_and_std(X, np.mean(H, axis=0))
@@ -369,28 +370,29 @@ def _confidence_plot(item, X, Y, H, bin_range, text_box=False, nsigma=3,
     # regions, so let's turn them off.
     for c in cset2.collections:
         c.set_linestyle('solid')
-
+    
     cbar = ax.figure.colorbar(contours)
     col_labels = [r'$3\sigma$', r'$2\sigma$', r'$1\sigma$'][3 - nsigma:]
     cbar.set_ticklabels(col_labels)
     cbar.set_label("Posterior probability" + cbar_note)
 
-    secax = ax.secondary_xaxis('top', functions=(pow10, np.log10))
+    if make_xticks:        
+        secax = ax.secondary_xaxis('top', functions=(pow10, np.log10))
 
-    if 'migd' in results[item]['config']['detector']:
-        x_ticks = [0.01, 0.1, 0.5, 1, 5, 10, 50, 100]
-    else:
-        x_ticks = [15, 25, 50, 100, 250, 500, 1000]
-    for x_tick in x_ticks:
-        ax.axvline(np.log10(x_tick), alpha=0.1)
-    secax.set_ticks(x_ticks)
-    secax.set_xticklabels([str(x) for x in x_ticks])
-    secax.xaxis.set_tick_params(rotation=45)
-    plt.xlim(*bin_range[0])
-    plt.ylim(*bin_range[1])
-    plt.xlabel(r"$\log_{10}(M_{\chi}$ $[GeV/c^{2}]$)")
-    secax.set_xlabel(r"$M_{\chi}$ $[GeV/c^{2}]$")
-    plt.ylabel(r"$\log_{10}(\sigma_{S.I.}$ $[cm^{2}]$)")
+        if 'migd' in results[item]['config']['detector']:
+            x_ticks = [0.01, 0.1, 0.5, 1, 5, 10, 50, 100]
+        else:
+            x_ticks = [15, 25, 50, 100, 250, 500, 1000]
+        for x_tick in x_ticks:
+            ax.axvline(np.log10(x_tick), alpha=0.1)
+        secax.set_ticks(x_ticks)
+        secax.set_xticklabels([str(x) for x in x_ticks])
+        secax.xaxis.set_tick_params(rotation=45)
+        plt.xlim(*bin_range[0])
+        plt.ylim(*bin_range[1])
+        plt.xlabel(r"$\log_{10}(M_{\chi}$ $[GeV/c^{2}]$)")
+        secax.set_xlabel(r"$M_{\chi}$ $[GeV/c^{2}]$")
+        plt.ylabel(r"$\log_{10}(\sigma_{S.I.}$ $[cm^{2}]$)")
 
     if text_box:
         plt.text(0.05, 0.95, text_box, transform=ax.transAxes, alpha=0.5,
@@ -638,7 +640,8 @@ def combined_confidence_plot(items,
                 text_box=text_box,
                 nsigma=nsigma,
                 cbar_note=cbar_notes[k],
-                cmap=cmap if cmap else colormaps[k],
+                cmap=cmap[k] if cmap else colormaps[k],
+                make_xticks =False,
                 alpha=alpha /
                 len(items) if combine else alpha)
             _results.append(res)
@@ -852,6 +855,7 @@ def combine_sets(items,
                     notes, [0, sub_number, number_i])]
                 def_show_single(it, _name, name_base, **kwargs)
                 exec_show(show)
+                
         if level > 0:
             f_print(f'at 1/{level}')
             for plot_times in range(2):

--- a/notebooks/load_results_multinest.py
+++ b/notebooks/load_results_multinest.py
@@ -310,7 +310,7 @@ def one_confidence_plot(
 
 
 def _confidence_plot(item, X, Y, H, bin_range, text_box=False, nsigma=3,
-                     make_xticks = True,
+                     make_xticks=True,
                      cbar_note="", cmap=cm.inferno_r, alpha=1,
                      ):
     xmean, xerr = weighted_avg_and_std(X, np.mean(H, axis=0))
@@ -370,13 +370,13 @@ def _confidence_plot(item, X, Y, H, bin_range, text_box=False, nsigma=3,
     # regions, so let's turn them off.
     for c in cset2.collections:
         c.set_linestyle('solid')
-    
+
     cbar = ax.figure.colorbar(contours)
     col_labels = [r'$3\sigma$', r'$2\sigma$', r'$1\sigma$'][3 - nsigma:]
     cbar.set_ticklabels(col_labels)
     cbar.set_label("Posterior probability" + cbar_note)
 
-    if make_xticks:        
+    if make_xticks:
         secax = ax.secondary_xaxis('top', functions=(pow10, np.log10))
 
         if 'migd' in results[item]['config']['detector']:
@@ -641,7 +641,7 @@ def combined_confidence_plot(items,
                 nsigma=nsigma,
                 cbar_note=cbar_notes[k],
                 cmap=cmap[k] if cmap else colormaps[k],
-                make_xticks =False,
+                make_xticks=False,
                 alpha=alpha /
                 len(items) if combine else alpha)
             _results.append(res)
@@ -855,7 +855,7 @@ def combine_sets(items,
                     notes, [0, sub_number, number_i])]
                 def_show_single(it, _name, name_base, **kwargs)
                 exec_show(show)
-                
+
         if level > 0:
             f_print(f'at 1/{level}')
             for plot_times in range(2):

--- a/scripts/run_combined_multinest
+++ b/scripts/run_combined_multinest
@@ -86,7 +86,7 @@ def set_config(model_simulator, args):
         'save_intermediate': args.save_intermediate,
         'fit_parameters': model_simulator.known_parameters[:args.nparams],
         'nlive': args.nlive,
-#        'E_max': args.e_max,
+        #        'E_max': args.e_max,
         'tol': args.tol}
 
     model_simulator.set_prior(args.priors_from)

--- a/scripts/run_combined_multinest
+++ b/scripts/run_combined_multinest
@@ -86,7 +86,7 @@ def set_config(model_simulator, args):
         'save_intermediate': args.save_intermediate,
         'fit_parameters': model_simulator.known_parameters[:args.nparams],
         'nlive': args.nlive,
-        'E_max': args.e_max,
+#        'E_max': args.e_max,
         'tol': args.tol}
 
     model_simulator.set_prior(args.priors_from)
@@ -170,23 +170,23 @@ def parse_arguments():
         help="Set to 0 (no print statements), 1 (some print statements) "
              "or >1 (a lot of print statements). Set the level of print "
              "statements while fitting.")
-    parser.add_argument(
-        '-save_intermediate',
-        type=str,
-        default="no",
-        help="yes / no / default, override internal determination if "
-             "we need to take into account earth shielding.")
+#    parser.add_argument(
+#        '-save_intermediate',
+#        type=str,
+#        default="no",
+#        help="yes / no / default, override internal determination if "
+#             "we need to take into account earth shielding.")
     parser.add_argument(
         '-multicore_hash',
         type=str,
         default="",
         help="no / default, override internal determination if we need "
              "to take into account earth shielding.")
-    parser.add_argument(
-        '-e_max',
-        type=int,
-        default=10,
-        help="Max energy to consider [keV]")
+#    parser.add_argument(
+#        '-e_max',
+#        type=int,
+#        default=10,
+#        help="Max energy to consider [keV]")
     parser.add_argument(
         '-target',
         type=str,

--- a/submit_to_stoomboot/Submit_monitor.ipynb
+++ b/submit_to_stoomboot/Submit_monitor.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/submit_to_stoomboot/write_script.py
+++ b/submit_to_stoomboot/write_script.py
@@ -38,6 +38,9 @@ parser.add_argument(
 parser.add_argument('--conda', type=str,
                     default=default_conda,
                     help="the anaconda path to be used by the script")
+parser.add_argument('--base_dir', type=str,
+                    default=base_dir,
+                    help="Where to look for scripts")
 parser.add_argument('--environment', type=str,
                     default=default_envr,
                     help="the anaconda environment to be sourced")
@@ -55,10 +58,12 @@ parser.add_argument('--mem', type=int,
 
 args = parser.parse_args()
 
+base_dir = args.base_dir
 #
 # where to write
 #
 _scriptfile = '%s_%s.sh' % ('dddm', args.arguments.replace("-", "_"))
+_scriptfile = _scriptfile.replace('_context_from_json /project/xenon/jorana/software/dddm_paper/dddm_context.json', '')
 if 'multicore_hash' in args.arguments:
     print(f'write_script.py::\tChange scriptfile name')
     script_split = _scriptfile.strip('.sh').split('multicore_hash')

--- a/submit_to_stoomboot/write_script.py
+++ b/submit_to_stoomboot/write_script.py
@@ -63,7 +63,8 @@ base_dir = args.base_dir
 # where to write
 #
 _scriptfile = '%s_%s.sh' % ('dddm', args.arguments.replace("-", "_"))
-_scriptfile = _scriptfile.replace('_context_from_json /project/xenon/jorana/software/dddm_paper/dddm_context.json', '')
+_scriptfile = _scriptfile.replace(
+    '_context_from_json /project/xenon/jorana/software/dddm_paper/dddm_context.json', '')
 if 'multicore_hash' in args.arguments:
     print(f'write_script.py::\tChange scriptfile name')
     script_split = _scriptfile.strip('.sh').split('multicore_hash')


### PR DESCRIPTION
## Bug `-save_intermediate`
Previously the `-save_intermediate` function was set to "no" as default while also being an boolean flag. This leads to confusion because `if args.save_intermediate` evaluates to `True` if it is a string.

## Ambiguous argument `-e_max` 
Additionally, the E_max argument was added as an aftermath. That argument is much better handled by the detector config files. It lead to some ambiguity of which place was responsible for the E-max. Additionally, we want to be able to set E-max to different values for different experiments. Without loss of generality. As such, one should be changing the config files instead of creating it here.

## Todo
 - [ ] there are some confusing entries where E-max is set as a default in the sampler classes. We should also remove those where possible.
 - [ ] Cleanup code by removing arguments instead of commenting out